### PR TITLE
ix_name join on service bridge data view for members

### DIFF
--- a/src/django_ixctl/rest/serializers/service_bridge.py
+++ b/src/django_ixctl/rest/serializers/service_bridge.py
@@ -28,6 +28,7 @@ class InternetExchange(ModelSerializer):
 @register
 class InternetExchangeMember(ModelSerializer):
     ix = serializers.SerializerMethodField()
+    ix_name = serializers.SerializerMethodField()
     pdb_ix_id = serializers.SerializerMethodField()
 
     class Meta:
@@ -37,6 +38,7 @@ class InternetExchangeMember(ModelSerializer):
             "ix_id",
             "pdb_ix_id",
             "ix",
+            "ix_name",
             "name",
             "speed",
             "asn",
@@ -51,6 +53,10 @@ class InternetExchangeMember(ModelSerializer):
         if "ix" in self.context.get("joins", []):
             return InternetExchange(instance=member.ix).data
         return None
+
+    def get_ix_name(self, member):
+        if "ix_name" in self.context.get("joins", []):
+            return member.ix.name
 
     def get_pdb_ix_id(self, member):
         return member.ix.pdb_id

--- a/src/django_ixctl/rest/views/service_bridge.py
+++ b/src/django_ixctl/rest/views/service_bridge.py
@@ -57,7 +57,7 @@ class InternetExchangeMember(DataViewSet):
         ("ip", MethodFilter("ip")),
     ]
 
-    join_xl = {"ix": ("ix",)}
+    join_xl = {"ix": ("ix",), "ix_name": ("ix",)}
 
     queryset = models.InternetExchangeMember.objects.filter(status="ok")
     serializer_class = Serializers.member


### PR DESCRIPTION
introduces ix_name only joining to service bridge view for member data - for cases where we dont really need the entire ix object joined in the data, but just the name